### PR TITLE
Add dark mode option

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,0 +1,19 @@
+root = document.documentElement
+themeName = 'pico8-syntax'
+
+module.exports =
+  activate: (state) ->
+    atom.config.observe "#{themeName}.darkMode", (value) ->
+      setDarkMode(value)
+
+deactivate: ->
+  unsetDarkMode()
+
+setDarkMode = (darkMode) ->
+  if darkMode
+    root.classList.add("pico8-dark-mode")
+  else
+    unsetDarkMode()
+
+unsetDarkMode = ->
+  root.classList.remove("pico8-dark-mode")

--- a/package.json
+++ b/package.json
@@ -11,8 +11,18 @@
     "pico-8"
   ],
   "repository": "https://github.com/catnipped/pico8-syntax",
+  "main": "lib/main",
   "license": "MIT",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"
+  },
+  "configSchema": {
+    "darkMode": {
+      "title": "Dark mode",
+      "description": "Dark blue background",
+      "type": "boolean",
+      "default": "false",
+      "order": 1
+    }
   }
 }

--- a/styles/base.less
+++ b/styles/base.less
@@ -51,6 +51,22 @@ atom-text-editor, :host {
   }
 }
 
+.pico8-dark-mode {
+  .meta {
+    &.separator {
+      background-color: @syntax-background-color-dark-mode;
+    }
+  }
+
+  atom-text-editor {
+    background-color: @syntax-background-color-dark-mode;
+
+    .gutter {
+      background-color: @syntax-gutter-background-color-dark-mode;
+    }
+  }
+}
+
 atom-text-editor .search-results .marker .region,
 :host .search-results .marker .region {
   background-color: transparent;

--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -9,6 +9,10 @@
 @syntax-selection-color: @p8-black;
 @syntax-background-color: @p8-dark-gray;
 
+// Dark mode
+@syntax-background-color-dark-mode: @p8-dark-blue;
+@syntax-gutter-background-color-dark-mode: @p8-dark-blue;
+
 // Guide colors
 @syntax-wrap-guide-color: @p8-indigo;
 @syntax-indent-guide-color: @p8-indigo;


### PR DESCRIPTION
Add option to turn on dark mode (#2), which changes the editor background color to dark blue, like PICO-8's `gui_theme` option.